### PR TITLE
Travis ci status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Address Book (Level 4)
 
-[![Build Status](https://travis-ci.org/se-edu/addressbook-level4.svg?branch=master)](https://travis-ci.org/se-edu/addressbook-level4)
+[![Build Status](https://travis-ci.org/CS2103JAN2017-T11-B4/main.svg?branch=master)](https://travis-ci.org/CS2103JAN2017-T11-B4/main.svg)
 [![Build status](https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true)](https://ci.appveyor.com/project/damithc/addressbook-level4)
 [![Coverage Status](https://coveralls.io/repos/github/se-edu/addressbook-level4/badge.svg?branch=master)](https://coveralls.io/github/se-edu/addressbook-level4?branch=master)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a)](https://www.codacy.com/app/damith/addressbook-level4?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=se-edu/addressbook-level4&amp;utm_campaign=Badge_Grade)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Address Book (Level 4)
 
-[![Build Status](https://travis-ci.org/CS2103JAN2017-T11-B4/main.svg?branch=master)](https://travis-ci.org/CS2103JAN2017-T11-B4/main.svg)
+[![Build Status](https://travis-ci.org/CS2103JAN2017-T11-B4/main.svg?branch=master)](https://travis-ci.org/CS2103JAN2017-T11-B4/main)
 [![Build status](https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true)](https://ci.appveyor.com/project/damithc/addressbook-level4)
 [![Coverage Status](https://coveralls.io/repos/github/se-edu/addressbook-level4/badge.svg?branch=master)](https://coveralls.io/github/se-edu/addressbook-level4?branch=master)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a)](https://www.codacy.com/app/damith/addressbook-level4?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=se-edu/addressbook-level4&amp;utm_campaign=Badge_Grade)


### PR DESCRIPTION
Changes the Travis CI build status image in the README to point to the build for this project (not the fork).